### PR TITLE
missing react-dom dependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "url": "adcentury/react-mobile-picker"
   },
   "dependencies": {
-    "react": "^0.14.3"
+    "react": "^0.14.3",
+    "react-dom": "~0.14.7"
   },
   "files": [
     "LICENCE",


### PR DESCRIPTION
`examples/main.js` use `react-dom` but it is not defined in the package.json, so the demo will not work