### PR TITLE
fix: 对handleTouchCancel中的startScrollerTranslate解构

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -175,7 +175,7 @@ class PickerColumn extends Component {
     if (!this.state.isMoving) {
       return;
     }
-    this.setState((startScrollerTranslate) => ({
+    this.setState(({ startScrollerTranslate }) => ({
       isMoving: false,
       startTouchY: 0,
       startScrollerTranslate: 0,


### PR DESCRIPTION
问题：滚动过程中触发handleTouchCancel，导致未解构的startScrollerTranslate（是一个对象），变为一个undefined。如果这时在使用的地方重新赋值options和value，会计算startScrollerTranslate，从而导致死循环