### PR TITLE
Add mouseMode prop for selecting items by click or drag

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,13 +127,14 @@ function MyPicker() {
 
 the main Picker container component.
 
-| Prop | Default | Description |
-| :---- | :------- | :----------- |
-| value | N/A | `{ [name: string]: string }`<br />Selected value pairs |
-| onChange | N/A | `(value: T, key: string) => void`<br />Callback function when the selected value changes |
-| height | 216 | `number`<br />Height of the picker in `px` |
-| itemHeight | 36 | `number`<br />Height of each item (that is each option) in `px` |
-| wheelMode | `'off'` | `'off' \| 'natural' \| 'normal'`<br />Enable wheel scrolling on desktop browsers |
+| Prop       | Default   | Description                                                                              |
+|:-----------|:----------|:-----------------------------------------------------------------------------------------|
+| value      | N/A       | `{ [name: string]: string }`<br />Selected value pairs                                   |
+| onChange   | N/A       | `(value: T, key: string) => void`<br />Callback function when the selected value changes |
+| height     | 216       | `number`<br />Height of the picker in `px`                                               |
+| itemHeight | 36        | `number`<br />Height of each item (that is each option) in `px`                          |
+| wheelMode  | `'off'`   | `'off' \| 'natural' \| 'normal'`<br />Enable wheel scrolling on desktop browsers         |
+| mouseMode  | `'click'` | `'click' \| 'drag'`<br />How to select an item with a mouse — by click or drag.          |
 
 ### Picker.Column
 

--- a/examples/containers/InlinePicker.tsx
+++ b/examples/containers/InlinePicker.tsx
@@ -30,6 +30,7 @@ export default function InlinePicker() {
       value={pickerValue}
       onChange={setPickerValue}
       wheelMode="natural"
+      mouseMode="drag"
     >
       <Picker.Column name="title">
         {renderOptions(['Mr.', 'Mrs.', 'Ms.', 'Dr.'], 'text-red-600')}

--- a/lib/components/Picker.tsx
+++ b/lib/components/Picker.tsx
@@ -3,6 +3,7 @@ import { CSSProperties, HTMLProps, MutableRefObject, createContext, useCallback,
 const DEFAULT_HEIGHT = 216
 const DEFAULT_ITEM_HEIGHT = 36
 const DEFAULT_WHEEL_MODE = 'off'
+const DEFAULT_MOUSE_MODE = 'click'
 
 interface Option {
   value: string | number
@@ -19,12 +20,14 @@ export interface PickerRootProps<TType extends PickerValue> extends Omit<HTMLPro
   height?: number
   itemHeight?: number
   wheelMode?: 'off' | 'natural' | 'normal'
+  mouseMode?: 'drag' | 'click'
 }
 
 const PickerDataContext = createContext<{
   height: number
   itemHeight: number
   wheelMode: 'off' | 'natural' | 'normal'
+  mouseMode: 'drag' | 'click'
   value: PickerValue
   optionGroups: { [key: string]: Option[] }
 } | null>(null)
@@ -118,6 +121,7 @@ function PickerRoot<TType extends PickerValue>(props: PickerRootProps<TType>) {
     height = DEFAULT_HEIGHT,
     itemHeight = DEFAULT_ITEM_HEIGHT,
     wheelMode = DEFAULT_WHEEL_MODE,
+    mouseMode= DEFAULT_MOUSE_MODE,
     ...restProps
   } = props
 
@@ -149,8 +153,8 @@ function PickerRoot<TType extends PickerValue>(props: PickerRootProps<TType>) {
   const [optionGroups, dispatch] = useReducer(pickerReducer, {})
 
   const pickerData = useMemo(
-    () => ({ height, itemHeight, wheelMode, value, optionGroups }),
-    [height, itemHeight, value, optionGroups, wheelMode]
+    () => ({ height, itemHeight, wheelMode, value, optionGroups, mouseMode }),
+    [height, itemHeight, value, optionGroups, wheelMode, mouseMode]
   )
   
   const triggerChange = useCallback((key: string, nextValue: string) => {

--- a/lib/components/PickerItem.tsx
+++ b/lib/components/PickerItem.tsx
@@ -23,7 +23,7 @@ function PickerItem({
   ...restProps
 }: PickerItemProps) {
   const optionRef = useRef<HTMLDivElement | null>(null)
-  const { itemHeight, value: pickerValue } = usePickerData('Picker.Item')
+  const { itemHeight, value: pickerValue, mouseMode } = usePickerData('Picker.Item')
   const pickerActions = usePickerActions('Picker.Item')
   const { key } = useColumnData('Picker.Item')
 
@@ -43,6 +43,7 @@ function PickerItem({
   )
 
   const handleClick = useCallback(() => {
+    if (mouseMode === 'drag') return
     pickerActions.change(key, value)
   }, [pickerActions, key, value])
 


### PR DESCRIPTION
Hi!

I’ve added a `mouseMode` prop that allows controlling the method of item selection with a mouse. Now, you can select an item either by clicking or by dragging, depending on the set value.

- Introduced the `mouseMode` prop with values 'click' and 'drag'.
- When set to 'click', the item will be selected by a mouse click as is currently implemented.
- When set to 'drag', the item will be selected by dragging, similar to mobile behavior


```jsx
import { useState } from 'react'
import Picker from 'react-mobile-picker'

function MyPicker() {
  const [pickerValue, setPickerValue] = useState({
    name1: 'item1',
    /* ... */
  })

  return (
    <Picker value={pickerValue} onChange={setPickerValue} mouseMode="drag">
      {/* ... */}
    </Picker>
  )
}
```